### PR TITLE
remove two spaces that break the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ A curated list of amazingly awesome open source resources for broadcasters inspi
 
 ## Subtitling
 
-* [EBU-TT-D Subtitling within dash.js] (https://github.com/ebu/dash.js/tree/ebu-subtitling-dev) - A fork of dash.js to experiment with XML based subtitles like EBU-TT-D within dash.js. Uses an HTML/CSS overlay.
-* [EBU-TT-D W3C XML Schema] (https://github.com/ebu/ebu-tt-d-xsd/) Informative EBU-TT-D XML Schema to support the implementation of EBU Tech 3380.
+* [EBU-TT-D Subtitling within dash.js](https://github.com/ebu/dash.js/tree/ebu-subtitling-dev) - A fork of dash.js to experiment with XML based subtitles like EBU-TT-D within dash.js. Uses an HTML/CSS overlay.
+* [EBU-TT-D W3C XML Schema](https://github.com/ebu/ebu-tt-d-xsd/) Informative EBU-TT-D XML Schema to support the implementation of EBU Tech 3380.
 * [Subtitling Conversion Framework (SCF)](https://github.com/Irt-Open-Source/scf) - A set of modules for converting subtitle formats. Main target is the conversion of EBU STL and EBU-TT subtitle files. Alpha release.
 
 # Resources


### PR DESCRIPTION
Note: rendering on github is OK with the spaces, but on http://ebu.io/opensource it is not.