### PR TITLE
Changes Rivendell url

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 
 * [Audacity](http://audacity.sourceforge.net/) - Cross-platform software for recording and editing sounds
 * [Airtime](https://www.sourcefabric.org/en/airtime/) - Radio management application for remote broadcast automation (via web-based schedule)
-* [Rivendell](http://www.rivendellaudio.org/) - Complete radio broadcast automation solution, translated to many languages and used worldwide. 
+* [Rivendell](https://github.com/ElvishArtisan/rivendell) - Complete radio broadcast automation solution, translated to many languages and used worldwide. 
 
 ## Software-defined radio
 


### PR DESCRIPTION
changing to official Github code rather than the commercial static homepage