### PR TITLE
Replaced Imaginary Teleprompter with QPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos) are themse
 * [Open Lighting Architecture (OLA)](https://www.openlighting.org/ola/) - Travel adaptor for the lighting industry, for interconnecting DMX-512, IP and USB.
 * [Q Light Controller+ (QLC+)](https://www.qlcplus.org/) - Cross-platform control of DMX or analogue lighting systems (heads, dimmers, etc.).
 * [TallyArbiter](http://tallyarbiter.com/) - Cross-platform Tally interfacer & tally lights for any camera via phones or low-cost hardware.
-* [Teleprompter](https://github.com/Cuperino/QPrompt) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
+* [QPrompt teleprompter app](https://github.com/Cuperino/QPrompt) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
 
 ## Streaming
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos) are themse
 * [Open Lighting Architecture (OLA)](https://www.openlighting.org/ola/) - Travel adaptor for the lighting industry, for interconnecting DMX-512, IP and USB.
 * [Q Light Controller+ (QLC+)](https://www.qlcplus.org/) - Cross-platform control of DMX or analogue lighting systems (heads, dimmers, etc.).
 * [TallyArbiter](http://tallyarbiter.com/) - Cross-platform Tally interfacer & tally lights for any camera via phones or low-cost hardware.
-* [Teleprompter](https://github.com/ImaginarySense/Imaginary-Teleprompter) - Web browser and standalone Electron app prompter.
+* [Teleprompter](https://github.com/Cuperino/QPrompt) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
 
 ## Streaming
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos) are themse
 * [Open Lighting Architecture (OLA)](https://www.openlighting.org/ola/) - Travel adaptor for the lighting industry, for interconnecting DMX-512, IP and USB.
 * [Q Light Controller+ (QLC+)](https://www.qlcplus.org/) - Cross-platform control of DMX or analogue lighting systems (heads, dimmers, etc.).
 * [TallyArbiter](http://tallyarbiter.com/) - Cross-platform Tally interfacer & tally lights for any camera via phones or low-cost hardware.
-* [QPrompt teleprompter app](https://github.com/Cuperino/QPrompt) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
+* [QPrompt teleprompter app](https://qprompt.app) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
 
 ## Streaming
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos) are themse
 * [MOS-connection](https://github.com/nrkno/tv-automation-mos-connection) - A JavaScript library for connection and MOS messaging either as MOS device or NRCS.
 * [Open Lighting Architecture (OLA)](https://www.openlighting.org/ola/) - Travel adaptor for the lighting industry, for interconnecting DMX-512, IP and USB.
 * [Q Light Controller+ (QLC+)](https://www.qlcplus.org/) - Cross-platform control of DMX or analogue lighting systems (heads, dimmers, etc.).
+* [QPrompt Teleprompter App](https://qprompt.app) - Convergent teleprompter software that works with studio teleprompters, tablet teleprompters, webcams, and phones.
 * [TallyArbiter](http://tallyarbiter.com/) - Cross-platform Tally interfacer & tally lights for any camera via phones or low-cost hardware.
-* [QPrompt teleprompter app](https://qprompt.app) - Convergent teleprompter software that integrates with your setup. Works with studio teleprompters, tablet teleprompters, webcams, and phones.
 
 ## Streaming
 


### PR DESCRIPTION
I'm Imaginary Teleprompter's lead developer and co-author. For the past year I've worked on a new teleprompter software to supersede Imaginary Teleprompter and have none of its technical limitations.

A few distinctions that make QPrompt more awesome than Imaginary Teleprompter are:
 * Works with both studio and tablet teleprompters
 * Fluid motion, jitter free experience
 * Paste from other software without hassle
 * Make changes from the prompter itself, while prompting
 * Prompt to multiple screens, with independent mirroring
 * Background transparency allows you to monitor yourself or your audience as you speak
 * Estimates remaining time for you
 * Countdown to start
 * Progress indicator
 * Supports writing systems of 182 languages