### PR TITLE
Added Studio TV Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 * [Open Playout Automation](https://github.com/jaskie/PlayoutAutomation) - A CasparCG-based MCR play-out system.
 * [ossia](https://ossia.io/) - A free and open-source intermedia sequencer.
 * [Sofie - TV Automation](https://github.com/nrkno/Sofie-TV-automation) - MOS-driven automation system for news casts, with many libraries for e.g. device control.
+* [Studio TV Player](https://github.com/jaskie/StudioTVPlayer) - Simple TV studio player with SDI, NDI and MPEG TS outputs.
 
 ## Hybrid Radio
 


### PR DESCRIPTION
Added studio player, which I started when worked in TVP. It's simple player using a cheap Windows PC, aimed to be a backup player if NRCS-controlled players fails.
It uses FFmpeg as decoder, Blackmagic Decklinks and NDI as ouputs, so no server machine or workstation is needed. It allows to control 2-3 channels (i. e. A-B playout and a video wall) simultaneously by one person, with several outputs assigned to single channel (i.e. NDI with timecodes and SDI without).