### PR TITLE
add vMix-EmberPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos) are themse
 * [Q Light Controller+ (QLC+)](https://www.qlcplus.org/) - Cross-platform control of DMX or analogue lighting systems (heads, dimmers, etc.).
 * [QPrompt Teleprompter App](https://qprompt.app) - Convergent teleprompter software that works with studio teleprompters, tablet teleprompters, webcams, and phones.
 * [TallyArbiter](http://tallyarbiter.com/) - Cross-platform Tally interfacer & tally lights for any camera via phones or low-cost hardware.
+* [vMix-EmberPlus](https://github.com/mattlamb99/vMix-EmberPlus) - vMix to EmberPlus gateway. Control vMix from any EmberPlus broadcast controller like Lawo's VSM or EVS's Cerebrum.
 
 ## Streaming
 


### PR DESCRIPTION
vMix to EmberPlus gateway - Convert vMix API to Emberplus for Broadcast controllers.

Disclaimer, I am author of the package.