### PR TITLE
BMX Lib ownership change

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 
 ## Metadata
 
-* [BMXlib](https://sourceforge.net/projects/bmxlib/) - Library and utilities to read and write broadcasting media files. Primarily supports the MXF file format.
+* [BMXlib](https://github.com/ebu/bmx) - Library and utilities to read and write broadcasting media files. Primarily supports the MXF file format.
 * [EBUCore](https://github.com/ebu/ebucore) - The Github for maintenance of the [EBUCore schema](https://tech.ebu.ch/docs/tech/tech3293.pdf).
 * [jebu-core](https://github.com/mikrosimage/jebu-core) - Java port of [EBU Tech 3293](https://tech.ebu.ch/publications/tech3293) EBU Core metadata, including the [Audio Definition Model](https://tech.ebu.ch/publications/tech3364).
 * [libadm](https://github.com/irt-open-source/libadm) - Audio Definition Model (ITU-R BS.2076) handling C++11 library.


### PR DESCRIPTION
> 👉 An [EBU](https://github.com/ebu) fork of bmx has been created at https://github.com/ebu/bmx
>
>The EBU fork has been made available to the bmx community to continue development of the project, as discussed in https://>github.com/bbc/bmx/issues/114

As it was collectively decided with BBC, EBU and relevant contributors: the ownership has been transfered from [SourceForge to BBC's GitHub](https://sourceforge.net/p/bmxlib/discussion/general/thread/58add986ea/?limit=25#6d14) and then [to EBU's GitHub](https://github.com/bbc/bmx/commit/278a9027580ea5f4a27d5d5040d5dc208c6ef538)