### PR TITLE
Add vastlint to SCTE-35 & SCTE-104

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos/) are thems
 ## SCTE-35 & SCTE-104
 
 * [threefive](https://github.com/superkabuki/threefive_is_scte35) - SCTE-35 Parser and Encoder for MPEGTS.
+* [vastlint](https://github.com/aleksUIX/vastlint) - Validator and linter for VAST video ad tags, useful for checking ad-serving and streaming ad insertion workflows.
 * [wireshark-scte](https://github.com/m1tk4/wireshark-scte) - SCTE-104 protocol dissector for Wireshark.
 * [x9k3](https://github.com/superkabuki/x9k3) - Adaptive Bit Rate HLS Segmenter and SCTE-35 Injector.
 


### PR DESCRIPTION
## Summary
- add `vastlint` under SCTE-35 & SCTE-104

## Why
- `vastlint` validates and lints VAST video ad tags
- while VAST is not SCTE-35 itself, it is commonly adjacent to streaming ad insertion and video ad signaling workflows that broadcasters and OTT teams debug alongside SCTE markers
- the project is open source and the primary link points to the code repository

## Disclosure
- I maintain vastlint, so this is a self-submission rather than a third-party recommendation.
