### PR TITLE
Add icey to Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The [Networked Media Open Specifications](https://specs.amwa.tv/nmos/) are thems
 
 ## Streaming
 
+* [icey](https://github.com/nilstate/icey) - C++ real-time media runtime for low-latency RTSP-to-browser distribution over WebRTC, built on libdatachannel and FFmpeg.
 * [Owncast](https://github.com/owncast/owncast) - Selfhosted video streaming platform (https://owncast.online/)
 * [PeerTube](https://github.com/Chocobozzz/PeerTube) - ActivityPub-federated video streaming platform using P2P directly in your web browser. (https://joinpeertube.org/)
 


### PR DESCRIPTION
icey is a C++20 real-time media runtime built on libdatachannel and FFmpeg. Primary use case is low-latency RTSP-to-browser via WebRTC, with built-in signalling and TURN. Useful in broadcasting workflows that need a self-hosted WebRTC distribution leg without a full media-server gateway.

- Repo: https://github.com/nilstate/icey
- Homepage: https://0state.com/icey
- License: LGPL-2.1+