### PR TITLE
Add mxf.js to Media Players

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 * [MPD](https://www.musicpd.org/) - A flexible, powerful, server-side application for playing music.
 * [mpg123](https://www.mpg123.de/) - A fast console MPEG Audio Player and decoder library.
 * [Mixxx](https://mixxx.org/) - A free, open source DJ software.
+* [mxf.js](https://github.com/emcodem/mxf.js) - Client-only browser-native MXF demuxer/player like hls.js for MPEG2 and H264.
 * [Peaks.js](https://codeberg.org/chrisn/peaks.js) - Browser-based audio waveform visualisation.
 * [rx-player](https://github.com/canalplus/rx-player) - HTML5/Javascript video player that supports MPEG-DASH and SmoothStreaming.
 * [VLC](https://www.vlc.org) - Simple, fast and powerful media player.


### PR DESCRIPTION
mxf.js is comparable to hls.js and dash.js and ships with a standalone 4:2:2 mpeg2 javascript decoder for XDCAM.
Therefore it can play XDCAM and H264 types like XAVC with all PCM channels natively in browser `<video>` element, from URL or local file.

Tester/Demo Page: https://emcodem.github.io/mxf.js/demo/index.html