### PR TITLE
Add emberviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 * [Bitfocus Companion](https://github.com/bitfocus/companion) - Enables the Elgato Streamdeck and other controllers to be a shotbox surface for an [increasing amount of broadcast equipment](https://bitfocus.io/connections). 
 * [Lawo EmberPlus](https://github.com/Lawo/ember-plus) - Ember Plus - open protocol for interfacing to / from broadcast control systems.
 * [MIDIMonster](https://github.com/cbdevnet/midimonster) - Lightweight adapter tool for common show control protocols.
+* [emberviewer](https://github.com/mattlamb99/emberviewer) - Cross-platform Ember+ viewer; browse providers, view/set parameters, route matrices, invoke functions, with an optional browser-based server mode.
 
 ## Distributed Media Processing
 


### PR DESCRIPTION
Add [emberviewer](https://github.com/mattlamb99/emberviewer) to Control Systems.

Cross-platform (Windows, macOS, Linux) open-source viewer for the Ember+ control protocol, and an open alternative to Lawo's Windows-only EmberPlusView. Browse providers, view and set parameters with live subscriptions, route matrices, invoke functions, view streamed meters, plus an optional browser-based server mode. MIT licensed.