### PR TITLE
Add streamtop to Monitoring & Quality Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ A curated list of amazingly awesome open source resources for broadcasters.
 * [silan](https://github.com/x42/silan) -  Audiofile silence analyzer.
 * [SilentJack](https://github.com/njh/silentjack) - Dead-air / Silence detector for JACK.
 * [Sonic Visualiser](https://www.sonicvisualiser.org/) - An application for viewing and analysing the contents of music audio files.
+* [streamtop](https://github.com/Jorji49/streamtop) - Terminal HLS, DASH, and IPTV stream monitor with TR 101 290 diagnostics and wire probes.
 * [VMAF](https://github.com/Netflix/vmaf) - Perceptual video quality assessment based on multi-method fusion.
 * [Wisual](https://github.com/MarcAntoine-Arnaud/wisual) - A web service for Visual Quality Assessment, which supports PSNR, SSIM, VQM, etc.
 


### PR DESCRIPTION
Adds streamtop to the **Monitoring & Quality Control** section in alphabetical order.

streamtop is an open-source Rust CLI/TUI tool designed for real-time passive diagnostics of HLS, MPEG-DASH, and IPTV streams, with support for TR 101 290 broadcast metrics and SCTE-35 cue analysis.